### PR TITLE
Clean up all temp files, fix exception

### DIFF
--- a/panelizer.py
+++ b/panelizer.py
@@ -30,13 +30,16 @@ import PUI
 import wx
 import tempfile
 
-_, kikit_tmp = tempfile.mkstemp(prefix='kikakuka_', suffix='.kicad_pcb')
+with tempfile.NamedTemporaryFile(prefix='kikakuka_', suffix='.kicad_pcb', delete=True) as tmp:
+    kikit_tmp = tmp.name
 
 def cleanup_kikit_tmp():
-    try:
-        os.remove(kikit_tmp)
-    except FileNotFoundError:
-        pass
+    try: os.remove(kikit_tmp)
+    except: pass
+    try: os.remove(kikit_tmp.replace("kicad_pcb", "kicad_pro"))
+    except: pass
+    try: os.remove(kikit_tmp.replace("kicad_pcb", "kicad_prl"))
+    except: pass
 
 VERSION = "3.5"
 


### PR DESCRIPTION
`mkstemp` creates the temp file and opens a filehandle - at least on Windows this generates an PermissionError when trying to delete it later: 
```
Traceback (most recent call last):
  File "C:\proj\Kikakuka\kikakuka.py", line 12, in <module>
    ui.load(None, inputs[0])
  File "C:\proj\Kikakuka\panelizer.py", line 609, in load
    pcb = PCB(file)
          ^^^^^^^^^
  File "C:\proj\Kikakuka\panelizer.py", line 112, in __init__
    cleanup_kikit_tmp()
  File "C:\proj\Kikakuka\panelizer.py", line 37, in cleanup_kikit_tmp
    os.remove(kikit_tmp)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\yoq\\AppData\\Local\\Temp\\kikakuka_d87h6wdb.kicad_pcb'
```

I also added code to clean up the pro/prl files as well.